### PR TITLE
fix: bug s3-download with 1 key as a prefix

### DIFF
--- a/AzureStorageWagon/pom.xml
+++ b/AzureStorageWagon/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>cloud-storage-maven</artifactId>
         <groupId>io.github.barrypitman</groupId>
-        <version>2.3.4</version>
+        <version>2.3.5-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/CloudStorageCore/pom.xml
+++ b/CloudStorageCore/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>cloud-storage-maven</artifactId>
         <groupId>io.github.barrypitman</groupId>
-        <version>2.3.4</version>
+        <version>2.3.5-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/GoogleStorageWagon/pom.xml
+++ b/GoogleStorageWagon/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>cloud-storage-maven</artifactId>
         <groupId>io.github.barrypitman</groupId>
-        <version>2.3.4</version>
+        <version>2.3.5-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -69,7 +69,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-plugin-plugin</artifactId>
-                <version>3.3</version>
+                <version>3.6.4</version>
                 <executions>
                     <execution>
                         <id>default-descriptor</id>

--- a/S3StorageWagon/pom.xml
+++ b/S3StorageWagon/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>cloud-storage-maven</artifactId>
         <groupId>io.github.barrypitman</groupId>
-        <version>2.3.4</version>
+        <version>2.3.5-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -12,7 +12,7 @@
     <description>S3 storage wagon</description>
 
     <properties>
-        <aws.version>1.11.743</aws.version>
+        <aws.version>1.12.305</aws.version>
         <httpcore>4.4.10</httpcore>
         <powermock.version>1.7.1</powermock.version>
     </properties>
@@ -99,7 +99,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-plugin-plugin</artifactId>
-                <version>3.3</version>
+                <version>3.6.4</version>
                 <executions>
                     <execution>
                         <id>default-descriptor</id>

--- a/S3StorageWagon/src/main/java/com/gkatzioura/maven/cloud/s3/plugin/PrefixKeysIterator.java
+++ b/S3StorageWagon/src/main/java/com/gkatzioura/maven/cloud/s3/plugin/PrefixKeysIterator.java
@@ -41,6 +41,10 @@ public class PrefixKeysIterator implements Iterator<String> {
         this.prefix = prefix;
     }
 
+    public String getPrefix() {
+        return this.prefix;
+    }
+
     @Override
     public void remove() {
         throw new UnsupportedOperationException();

--- a/S3StorageWagon/src/main/java/com/gkatzioura/maven/cloud/s3/plugin/download/S3DownloadMojo.java
+++ b/S3StorageWagon/src/main/java/com/gkatzioura/maven/cloud/s3/plugin/download/S3DownloadMojo.java
@@ -19,6 +19,7 @@ package com.gkatzioura.maven.cloud.s3.plugin.download;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
 import java.util.logging.Level;
@@ -34,11 +35,9 @@ import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.wagon.authentication.AuthenticationException;
 
 import com.amazonaws.services.s3.AmazonS3;
-import com.amazonaws.services.s3.AmazonS3ClientBuilder;
 import com.amazonaws.services.s3.S3ClientOptions;
 import com.amazonaws.services.s3.model.S3Object;
 import com.amazonaws.services.s3.model.S3ObjectInputStream;
-import com.gkatzioura.maven.cloud.KeyIteratorConcated;
 import com.gkatzioura.maven.cloud.s3.EndpointProperty;
 import com.gkatzioura.maven.cloud.s3.PathStyleEnabledProperty;
 import com.gkatzioura.maven.cloud.s3.plugin.PrefixKeysIterator;
@@ -88,49 +87,25 @@ public class S3DownloadMojo extends AbstractMojo {
                     e);
         }
 
-        if (keys.size()==1) {
-            downloadSingleFile(amazonS3,keys.get(0));
-            return;
-        }
-
         List<Iterator<String>> prefixKeysIterators = keys.stream()
-                                                 .map(pi -> new PrefixKeysIterator(amazonS3, bucket, pi))
+                                                 .map(pi -> pi.endsWith("/") ? new PrefixKeysIterator(amazonS3, bucket, pi) : Arrays.asList(pi).iterator())
                                                  .collect(Collectors.toList());
-        Iterator<String> keyIteratorConcated = new KeyIteratorConcated(prefixKeysIterators);
 
-        while (keyIteratorConcated.hasNext()) {
+        for (Iterator<String> iterator : prefixKeysIterators) {
 
-            String key = keyIteratorConcated.next();
-            downloadFile(amazonS3,key);
+            String prefix = null;
+            if (iterator instanceof PrefixKeysIterator) {
+                prefix = ((PrefixKeysIterator) iterator).getPrefix();
+            }
+
+            while (iterator.hasNext()) {
+                String key = iterator.next();
+                downloadFile(amazonS3, prefix, key);
+            }
         }
     }
 
-    private void downloadSingleFile(AmazonS3 amazonS3,String key) {
-        File file = new File(downloadPath);
-
-        if(file.getParentFile()!=null) {
-            file.getParentFile().mkdirs();
-        }
-
-        S3Object s3Object = amazonS3.getObject(bucket, key);
-
-        try(S3ObjectInputStream s3ObjectInputStream = s3Object.getObjectContent();
-            FileOutputStream fileOutputStream = new FileOutputStream(file)
-        ) {
-            IOUtils.copy(s3ObjectInputStream,fileOutputStream);
-        } catch (IOException e) {
-            LOGGER.log(Level.SEVERE, "Could not download s3 file");
-            e.printStackTrace();
-        }
-    }
-
-    private void downloadFile(AmazonS3 amazonS3,String key) {
-
-        File file = new File(createFullFilePath(key));
-
-        if(file.getParent()!=null) {
-            file.getParentFile().mkdirs();
-        }
+    private void downloadFile(AmazonS3 amazonS3, String prefix, String key) {
 
         S3Object s3Object = amazonS3.getObject(bucket, key);
 
@@ -138,6 +113,12 @@ public class S3DownloadMojo extends AbstractMojo {
             return;
         }
 
+        File file = new File(createFullFilePath(prefix, key));
+
+        if(file.getParent()!=null) {
+            file.getParentFile().mkdirs();
+        }
+
         try(S3ObjectInputStream s3ObjectInputStream = s3Object.getObjectContent();
             FileOutputStream fileOutputStream = new FileOutputStream(file)
         ) {
@@ -148,14 +129,14 @@ public class S3DownloadMojo extends AbstractMojo {
         }
     }
 
-    private final String createFullFilePath(String key) {
+    private final String createFullFilePath(String prefix,String key) {
 
-        String fullPath = downloadPath+"/"+key;
+        String fullPath = downloadPath+"/"+ ( prefix != null ? key.substring(key.indexOf(prefix) + prefix.length()) : key);
         return fullPath;
     }
 
     private final boolean isDirectory(S3Object s3Object) {
-        return s3Object.getObjectMetadata().getContentType().equals(DIRECTORY_CONTENT_TYPE);
+        return s3Object.getObjectMetadata().getContentType().startsWith(DIRECTORY_CONTENT_TYPE);
     }
 
 

--- a/S3StorageWagon/src/test/java/com/gkatzioura/maven/cloud/s3/S3StorageWagonTest.java
+++ b/S3StorageWagon/src/test/java/com/gkatzioura/maven/cloud/s3/S3StorageWagonTest.java
@@ -35,11 +35,6 @@ public class S3StorageWagonTest extends WagonTestCase {
         return "s3";
     }
 
-    @Override
-    protected int getTestRepositoryPort() {
-        return 0;
-    }
-
     //TODO se tit to true and fix the failing tests
     protected boolean supportsGetIfNewer()
     {

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <groupId>io.github.barrypitman</groupId>
     <artifactId>cloud-storage-maven</artifactId>
     <packaging>pom</packaging>
-    <version>2.3.4</version>
+    <version>2.3.5-SNAPSHOT</version>
 
     <name>Cloud Storage</name>
     <description>The CloudStorage project enables you to use the storage options of cloud provides (Google Cloud)
@@ -46,12 +46,12 @@
     </scm>
 
     <properties>
-        <wagon.version>3.0.0</wagon.version>
+        <wagon.version>3.5.2</wagon.version>
         <logback.version>1.2.3</logback.version>
         <commons-io.version>2.6</commons-io.version>
-        <junit.version>4.12</junit.version>
-        <maven.plugin.api.version>3.0</maven.plugin.api.version>
-        <maven.plugin.annotations.version>3.4</maven.plugin.annotations.version>
+        <junit.version>4.13.2</junit.version>
+        <maven.plugin.api.version>3.6.3</maven.plugin.api.version>
+        <maven.plugin.annotations.version>3.6.4</maven.plugin.annotations.version>
     </properties>
 
     <distributionManagement>
@@ -73,7 +73,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.7.0</version>
+                <version>3.10.1</version>
                 <configuration>
                     <source>1.8</source>
                     <target>1.8</target>


### PR DESCRIPTION
When 1 key is specified for "s3-download" maven-task, this key must be only file key. On the other side, when specified 2 or more keys, all they are processed as prefixes keys. With this commit this behavior changed. Now prefixes differs from files: prefixes ends with "/", files - not. Prefix can be specialized on every place in "keys" parameters or quite not specialized.