### PR TITLE
Cache BlobServiceClient instances to reuse Azure AD tokens

### DIFF
--- a/AzureStorageWagon/src/main/java/com/gkatzioura/maven/cloud/abs/AzureClientFactory.java
+++ b/AzureStorageWagon/src/main/java/com/gkatzioura/maven/cloud/abs/AzureClientFactory.java
@@ -23,6 +23,9 @@ import com.azure.storage.blob.BlobServiceClientBuilder;
 import org.apache.maven.wagon.authentication.AuthenticationException;
 import org.apache.maven.wagon.authentication.AuthenticationInfo;
 
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.logging.Logger;
 
 public class AzureClientFactory {
@@ -30,6 +33,12 @@ public class AzureClientFactory {
     private static final String CONNECTION_STRING_TEMPLATE = "DefaultEndpointsProtocol=https;AccountName=%s;AccountKey=%s;EndpointSuffix=core.windows.net";
 
     private static final Logger LOGGER = Logger.getLogger(AzureClientFactory.class.getName());
+
+    /**
+     * Cache service clients per endpoint/credential combination so the Azure Identity token cache
+     * can be reused across wagon instances.
+     */
+    private static final Map<AuthenticationKey, BlobServiceClient> CLIENT_CACHE = new ConcurrentHashMap<>();
 
     public BlobServiceClient create(AuthenticationInfo authenticationInfo) throws AuthenticationException {
 
@@ -42,28 +51,84 @@ public class AzureClientFactory {
 
         if (username == null || username.isEmpty()) {
             // if no username is provided, then we expect that the password is a shared access signature (SAS) URL
-            return new BlobServiceClientBuilder()
+            AuthenticationKey key = AuthenticationKey.forSas(password);
+            return CLIENT_CACHE.computeIfAbsent(key, ignored -> new BlobServiceClientBuilder()
                     .endpoint(password)
-                    .buildClient();
+                    .buildClient());
 
         } else if (authenticationInfo.getPassphrase() != null && !authenticationInfo.getPassphrase().isEmpty()) {
             // if no password is provided, then we expect that the username is the path to a properties file, which contains
             // the following properties: client_id, client_secret, tenant_id and storage_account_url properties,
             // for use when authenticating via Azure AD
-            ClientSecretCredential credential = new ClientSecretCredentialBuilder()
-                    .clientId(authenticationInfo.getUserName())
-                    .clientSecret(authenticationInfo.getPassword())
-                    .tenantId(authenticationInfo.getPassphrase())
-                    .build();
-            return new BlobServiceClientBuilder()
-                    .endpoint(authenticationInfo.getPrivateKey())
-                    .credential(credential)
-                    .buildClient();
+            AuthenticationKey key = AuthenticationKey.forAad(username, password, authenticationInfo.getPassphrase(), authenticationInfo.getPrivateKey());
+            return CLIENT_CACHE.computeIfAbsent(key, ignored -> {
+                ClientSecretCredential credential = new ClientSecretCredentialBuilder()
+                        .clientId(authenticationInfo.getUserName())
+                        .clientSecret(authenticationInfo.getPassword())
+                        .tenantId(authenticationInfo.getPassphrase())
+                        .build();
+                return new BlobServiceClientBuilder()
+                        .endpoint(authenticationInfo.getPrivateKey())
+                        .credential(credential)
+                        .buildClient();
+            });
 
         } else {
-            return new BlobServiceClientBuilder()
-                    .connectionString(String.format(CONNECTION_STRING_TEMPLATE, username, password))
-                    .buildClient();
+            String connectionString = String.format(CONNECTION_STRING_TEMPLATE, username, password);
+            AuthenticationKey key = AuthenticationKey.forConnectionString(connectionString);
+            return CLIENT_CACHE.computeIfAbsent(key, ignored -> new BlobServiceClientBuilder()
+                    .connectionString(connectionString)
+                    .buildClient());
+        }
+    }
+
+    private static final class AuthenticationKey {
+
+        private final String type;
+        private final String username;
+        private final String password;
+        private final String passphrase;
+        private final String endpoint;
+
+        private AuthenticationKey(String type, String username, String password, String passphrase, String endpoint) {
+            this.type = type;
+            this.username = username;
+            this.password = password;
+            this.passphrase = passphrase;
+            this.endpoint = endpoint;
+        }
+
+        static AuthenticationKey forSas(String endpoint) {
+            return new AuthenticationKey("sas", null, null, null, endpoint);
+        }
+
+        static AuthenticationKey forAad(String username, String password, String passphrase, String endpoint) {
+            return new AuthenticationKey("aad", username, password, passphrase, endpoint);
+        }
+
+        static AuthenticationKey forConnectionString(String connectionString) {
+            return new AuthenticationKey("connection", null, connectionString, null, null);
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (!(o instanceof AuthenticationKey)) {
+                return false;
+            }
+            AuthenticationKey that = (AuthenticationKey) o;
+            return Objects.equals(type, that.type)
+                    && Objects.equals(username, that.username)
+                    && Objects.equals(password, that.password)
+                    && Objects.equals(passphrase, that.passphrase)
+                    && Objects.equals(endpoint, that.endpoint);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(type, username, password, passphrase, endpoint);
         }
     }
 


### PR DESCRIPTION
### Motivation
- Multiple wagon connections were creating fresh Azure clients/credentials which caused repeated token acquisition and log noise for every downloaded artifact.
- Reusing client/credential instances allows the Azure Identity library to reuse its in-memory token cache and avoid repeated authentication calls.

### Description
- Add a static concurrent `CLIENT_CACHE` in `AzureClientFactory` to hold `BlobServiceClient` instances keyed by an `AuthenticationKey` value type. 
- Switch all three auth paths (SAS endpoint, Azure AD client-secret, and connection-string) to use `CLIENT_CACHE.computeIfAbsent(...)` to reuse existing clients instead of creating new ones. 
- Introduce `AuthenticationKey` with deterministic `equals`/`hashCode` implementations to ensure correct cache lookup per authentication parameters.

### Testing
- Attempted to build the Azure wagon module with `mvn -pl AzureStorageWagon -am test -DskipTests`, but the build could not complete due to external plugin resolution errors (`403 Forbidden` from Maven Central) in this environment, so compilation/tests were not verified here.
- No additional automated tests were run; change is limited to client creation/caching logic in `AzureClientFactory` (file: `AzureStorageWagon/src/main/java/com/gkatzioura/maven/cloud/abs/AzureClientFactory.java`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_699c08146a1883219aeed3acf7f3031f)