### PR TITLE
Fix CI GPG signing setup and pin Maven plugin versions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -6,17 +6,19 @@ jobs:
     publish:
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@v3
+            - uses: actions/checkout@v4
             - name: Set up Maven Central Repository
-              uses: actions/setup-java@v3
+              uses: actions/setup-java@v4
               with:
                   java-version: '8'
-                  distribution: 'adopt'
+                  distribution: 'temurin'
                   server-id: sonatype-nexus-staging
                   server-username: MAVEN_USERNAME
                   server-password: MAVEN_PASSWORD
                   gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }}
                   gpg-passphrase: GPG_PASSPHRASE
+              env:
+                  GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
 
             - name: Publish package
               run: mvn --batch-mode deploy -P deploy

--- a/pom.xml
+++ b/pom.xml
@@ -82,6 +82,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>
+                <version>3.4.0</version>
                 <executions>
                     <execution>
                         <id>attach-sources</id>
@@ -94,6 +95,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
+                <version>3.12.0</version>
                 <executions>
                     <execution>
                         <id>attach-javadocs</id>


### PR DESCRIPTION
### Motivation
- The GitHub Actions deploy run was failing with `gpg: no default secret key`, indicating the signing key was not imported/unlocked before Maven attempted to sign artifacts. 
- The parent `pom.xml` produced warnings about missing plugin versions which can cause unstable plugin resolution and future build breakage.

### Description
- Updated `.github/workflows/deploy.yml` to use `actions/checkout@v4` and `actions/setup-java@v4`, switched `distribution` to `temurin`, and exposed `GPG_PASSPHRASE` in the `setup-java` step so the action can import/unlock the GPG key before `mvn deploy` runs. 
- Kept the deploy step environment intact and ensured `GPG_PASSPHRASE` remains available to the `mvn` run. 
- Pinned versions in the parent `pom.xml` by setting `maven-source-plugin` to `3.4.0` and `maven-javadoc-plugin` to `3.12.0` to remove model warnings and make plugin resolution deterministic. 

### Testing
- Ran `mvn --batch-mode -DskipTests verify` in this environment which failed to complete because Maven Central returned HTTP 403 when fetching plugin artifacts, so full verification could not be completed here. 
- The changes were committed and are ready for a CI run; if the workflow still fails the next likely step is to rotate or re-upload the `GPG_PRIVATE_KEY` secret if it has expired or been revoked.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_699c53569f4c8321ad84c4d6ce5df65d)