### PR TITLE
Fix download transfer progress content length handling

### DIFF
--- a/CloudStorageCore/src/main/java/com/gkatzioura/maven/cloud/listener/TransferListenerContainerImpl.java
+++ b/CloudStorageCore/src/main/java/com/gkatzioura/maven/cloud/listener/TransferListenerContainerImpl.java
@@ -62,7 +62,11 @@ public class TransferListenerContainerImpl implements TransferListenerContainer 
 
     @Override
     public void fireTransferStarted(Resource resource, int requestType, File localFile) {
-        resource.setContentLength(localFile.length());
+        if (requestType == TransferEvent.REQUEST_PUT) {
+            resource.setContentLength(localFile.length());
+        } else if (resource.getContentLength() <= 0) {
+            resource.setContentLength(-1L);
+        }
         resource.setLastModified(localFile.lastModified());
         TransferEvent transferEvent = new TransferEvent(this.wagon,resource,TransferEvent.TRANSFER_STARTED,requestType);
         transferEvent.setLocalFile(localFile);

--- a/CloudStorageCore/src/test/java/com/gkatzioura/maven/cloud/listener/TransferListenerContainerImplTest.java
+++ b/CloudStorageCore/src/test/java/com/gkatzioura/maven/cloud/listener/TransferListenerContainerImplTest.java
@@ -1,0 +1,75 @@
+package com.gkatzioura.maven.cloud.listener;
+
+import org.apache.maven.wagon.Wagon;
+import org.apache.maven.wagon.events.TransferEvent;
+import org.apache.maven.wagon.events.TransferListener;
+import org.apache.maven.wagon.resource.Resource;
+import org.junit.Test;
+
+import java.io.File;
+import java.io.IOException;
+
+import static org.junit.Assert.assertEquals;
+
+public class TransferListenerContainerImplTest {
+
+    @Test
+    public void fireTransferStartedSetsUnknownLengthForGetWhenLengthIsNotKnown() throws IOException {
+        TransferListenerContainerImpl container = new TransferListenerContainerImpl((Wagon) null);
+        Resource resource = new Resource("artifact.pom");
+        File localFile = File.createTempFile("transfer", ".tmp");
+        localFile.deleteOnExit();
+
+        TransferStartedCaptureListener listener = new TransferStartedCaptureListener();
+        container.addTransferListener(listener);
+
+        container.fireTransferStarted(resource, TransferEvent.REQUEST_GET, localFile);
+
+        assertEquals(-1L, listener.lastEvent.getResource().getContentLength());
+    }
+
+    @Test
+    public void fireTransferStartedUsesLocalFileLengthForPut() throws IOException {
+        TransferListenerContainerImpl container = new TransferListenerContainerImpl((Wagon) null);
+        Resource resource = new Resource("artifact.pom");
+        File localFile = File.createTempFile("transfer", ".tmp");
+        localFile.deleteOnExit();
+
+        TransferStartedCaptureListener listener = new TransferStartedCaptureListener();
+        container.addTransferListener(listener);
+
+        container.fireTransferStarted(resource, TransferEvent.REQUEST_PUT, localFile);
+
+        assertEquals(localFile.length(), listener.lastEvent.getResource().getContentLength());
+    }
+
+    private static class TransferStartedCaptureListener implements TransferListener {
+
+        private TransferEvent lastEvent;
+
+        @Override
+        public void transferInitiated(TransferEvent transferEvent) {
+        }
+
+        @Override
+        public void transferStarted(TransferEvent transferEvent) {
+            this.lastEvent = transferEvent;
+        }
+
+        @Override
+        public void transferProgress(TransferEvent transferEvent, byte[] bytes, int i) {
+        }
+
+        @Override
+        public void transferCompleted(TransferEvent transferEvent) {
+        }
+
+        @Override
+        public void transferError(TransferEvent transferEvent) {
+        }
+
+        @Override
+        public void debug(String s) {
+        }
+    }
+}


### PR DESCRIPTION
### Motivation
- Downloads could set the resource content length from the (often-empty) destination file which caused Maven's progress formatter to throw `IllegalArgumentException: progressed file size cannot be greater than size` and hang builds when progress reporting was enabled.
- The change ensures download (GET) transfers do not provide an incorrect zero size for in-progress transfers, preventing the formatter crash.

### Description
- Update `TransferListenerContainerImpl.fireTransferStarted` to only set the resource content length from the local file for `REQUEST_PUT` (uploads), and for non-PUT requests set the content length to `-1` when the size is not known.
- Preserve `lastModified` and continue dispatching the `TRANSFER_STARTED` event with the local file as before.
- Add unit tests `TransferListenerContainerImplTest` that assert GET transfers set an unknown length (`-1`) when size is not known and PUT transfers still use the local file length.

### Testing
- Added unit tests under `CloudStorageCore/src/test/java/.../TransferListenerContainerImplTest.java` that cover GET and PUT `TRANSFER_STARTED` behavior and validate content length handling.
- Attempted to run `mvn -pl CloudStorageCore test -DskipITs` but the build environment failed plugin resolution for `maven-source-plugin` (HTTP 403 from Maven Central), so the test execution did not complete in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69a697b113288321ad16151574454dd6)