### PR TITLE
Add Azure AD DefaultAzureCredential support and bump project version to 2.3.9

### DIFF
--- a/AzureStorageWagon/README.adoc
+++ b/AzureStorageWagon/README.adoc
@@ -19,13 +19,25 @@ Add the wagon dependency to your pom.xml file as a build extension.
 
 == Authentication methods
 
-You can authenticate to Azure using 3 different methods:
+You can authenticate to Azure using 4 different methods:
 
 === Access keys
 This is the original solution. In settings.xml, the username should contain the storage account name, and the password should contain a storage account access key. The disadvantage to this approach is that storage account keys allow for complete control over the entire storage account. Most users only require READ access.
 
 === Shared access signatures
 To use shared access signatures, specify the shared access signature in the settings.xml username field, and leave the password empty. SAS give a better level of control compared to access keys, and can be scoped to particular directories, and restricted to read-only access where required. However, this solution might not scale well to many users, since SAS tokens cannot be revoked without rotating access keys and invalidating all SAS signatures.
+
+=== Azure AD using default credentials
+You can also authenticate via the Azure Identity default credential chain. This uses the signed-in developer identity (for example `az login`), managed identity, workload identity, or environment credentials depending on where Maven runs.
+
+To use this mode, configure only the storage endpoint (`privateKey`) in `settings.xml` and leave the other credential fields empty:
+
+- username: empty
+- password: empty
+- passphrase: empty
+- privateKey: endpoint (e.g. https://<name>.blob.core.windows.net)
+
+This is ideal for local developer machines because each user can use their own identity and RBAC assignments.
 
 === Azure AD using service principal
 If your storage account uses Azure AD for authentication (https://docs.microsoft.com/en-us/azure/storage/blobs/authorize-access-azure-active-directory), then you can also use a service principal for authentication. To use Azure AD authentication the fields in settings.xml should be configured as follows:

--- a/AzureStorageWagon/pom.xml
+++ b/AzureStorageWagon/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>cloud-storage-maven</artifactId>
         <groupId>io.github.barrypitman</groupId>
-        <version>2.3.7</version>
+        <version>2.3.9</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/AzureStorageWagon/src/main/java/com/gkatzioura/maven/cloud/abs/AzureClientFactory.java
+++ b/AzureStorageWagon/src/main/java/com/gkatzioura/maven/cloud/abs/AzureClientFactory.java
@@ -18,6 +18,8 @@ package com.gkatzioura.maven.cloud.abs;
 
 import com.azure.identity.ClientSecretCredential;
 import com.azure.identity.ClientSecretCredentialBuilder;
+import com.azure.identity.DefaultAzureCredential;
+import com.azure.identity.DefaultAzureCredentialBuilder;
 import com.azure.storage.blob.BlobServiceClient;
 import com.azure.storage.blob.BlobServiceClientBuilder;
 import org.apache.maven.wagon.authentication.AuthenticationException;
@@ -48,18 +50,32 @@ public class AzureClientFactory {
 
         String username = authenticationInfo.getUserName();
         String password = authenticationInfo.getPassword();
+        String passphrase = authenticationInfo.getPassphrase();
+        String endpoint = authenticationInfo.getPrivateKey();
 
-        if (username == null || username.isEmpty()) {
+        if ((username == null || username.isEmpty())
+                && (password == null || password.isEmpty())
+                && (passphrase == null || passphrase.isEmpty())
+                && endpoint != null && !endpoint.isEmpty()) {
+            // Azure AD default credential chain (CLI login, managed identity, environment, workload identity, etc)
+            AuthenticationKey key = AuthenticationKey.forDefaultCredential(endpoint);
+            return CLIENT_CACHE.computeIfAbsent(key, ignored -> {
+                DefaultAzureCredential credential = new DefaultAzureCredentialBuilder().build();
+                return new BlobServiceClientBuilder()
+                        .endpoint(endpoint)
+                        .credential(credential)
+                        .buildClient();
+            });
+
+        } else if (username == null || username.isEmpty()) {
             // if no username is provided, then we expect that the password is a shared access signature (SAS) URL
             AuthenticationKey key = AuthenticationKey.forSas(password);
             return CLIENT_CACHE.computeIfAbsent(key, ignored -> new BlobServiceClientBuilder()
                     .endpoint(password)
                     .buildClient());
 
-        } else if (authenticationInfo.getPassphrase() != null && !authenticationInfo.getPassphrase().isEmpty()) {
-            // if no password is provided, then we expect that the username is the path to a properties file, which contains
-            // the following properties: client_id, client_secret, tenant_id and storage_account_url properties,
-            // for use when authenticating via Azure AD
+        } else if (passphrase != null && !passphrase.isEmpty()) {
+            // Azure AD service principal credentials provided directly in settings.xml
             AuthenticationKey key = AuthenticationKey.forAad(username, password, authenticationInfo.getPassphrase(), authenticationInfo.getPrivateKey());
             return CLIENT_CACHE.computeIfAbsent(key, ignored -> {
                 ClientSecretCredential credential = new ClientSecretCredentialBuilder()
@@ -108,6 +124,10 @@ public class AzureClientFactory {
 
         static AuthenticationKey forConnectionString(String connectionString) {
             return new AuthenticationKey("connection", null, connectionString, null, null);
+        }
+
+        static AuthenticationKey forDefaultCredential(String endpoint) {
+            return new AuthenticationKey("default", null, null, null, endpoint);
         }
 
         @Override

--- a/CloudStorageCore/pom.xml
+++ b/CloudStorageCore/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>cloud-storage-maven</artifactId>
         <groupId>io.github.barrypitman</groupId>
-        <version>2.3.7</version>
+        <version>2.3.9</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/GoogleStorageWagon/pom.xml
+++ b/GoogleStorageWagon/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>cloud-storage-maven</artifactId>
         <groupId>io.github.barrypitman</groupId>
-        <version>2.3.7</version>
+        <version>2.3.9</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/S3StorageWagon/pom.xml
+++ b/S3StorageWagon/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>cloud-storage-maven</artifactId>
         <groupId>io.github.barrypitman</groupId>
-        <version>2.3.7</version>
+        <version>2.3.9</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <groupId>io.github.barrypitman</groupId>
     <artifactId>cloud-storage-maven</artifactId>
     <packaging>pom</packaging>
-    <version>2.3.7</version>
+    <version>2.3.9</version>
 
     <name>Cloud Storage</name>
     <description>The CloudStorage project enables you to use the storage options of cloud provides (Google Cloud)


### PR DESCRIPTION
### Motivation
- Add support for the Azure Identity default credential chain so developers and managed workloads can authenticate without embedding secrets in `settings.xml`.
- Document the new authentication option for Azure AD default credentials in the wagon README.
- Bump the project parent version to `2.3.9` across modules.

### Description
- Add `DefaultAzureCredential` usage to `AzureClientFactory` and use it when `username`, `password`, and `passphrase` are empty but `privateKey` (endpoint) is provided, reusing a client cache keyed by a new `forDefaultCredential` type.
- Refactor `AzureClientFactory` to explicitly read `passphrase` and `privateKey` from `AuthenticationInfo`, and preserve the existing SAS, connection-string, and service-principal (AAD) flows using cached `BlobServiceClient` instances.
- Extend `AuthenticationKey` with `forDefaultCredential` and include `endpoint` in equality/hash to ensure proper caching.
- Document the new "Azure AD using default credentials" authentication method in `AzureStorageWagon/README.adoc` with example `settings.xml` fields.
- Bump parent/project versions from `2.3.7` to `2.3.9` in `pom.xml` files for the root and affected modules (`CloudStorageCore`, `AzureStorageWagon`, `GoogleStorageWagon`, `S3StorageWagon`).

### Testing
- Built the project to verify compilation using `mvn -DskipTests package`, which completed successfully.
- No new unit tests were added as part of this change and existing tests were not modified.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69f7b8d4f50083218735be4d9d9ba49a)